### PR TITLE
Simplify documentation titles and add examples

### DIFF
--- a/R/effect_blueprint.R
+++ b/R/effect_blueprint.R
@@ -1,5 +1,13 @@
 
-#' Blueprint (cyanotype) style
+#' Blueprint style
+#'
+#' Creates a cyanotype blueprint effect with optional grid and paper texture.
+#'
+#' @examples
+#' if (requireNamespace("magick", quietly = TRUE)) {
+#'   img <- magick::image_read("logo:")
+#'   patina_blueprint(img)
+#' }
 #'
 #' @param img magick image.
 #' @param bg Blueprint background color.

--- a/R/effect_edu_film.R
+++ b/R/effect_edu_film.R
@@ -1,4 +1,13 @@
-#' Old educational film preset (warm/green cast, big grain, dust & scratches)
+#' Old educational film preset
+#'
+#' Adds a warm/green cast, heavy grain, dust, scratches, and slight weave for a
+#' classroom 16mm look.
+#'
+#' @examples
+#' if (requireNamespace("magick", quietly = TRUE)) {
+#'   img <- magick::image_read("logo:")
+#'   patina_edu_film(img)
+#' }
 #' @param img magick image
 #' @param warmth 0..1 warm/green cast (0=none)
 #' @param grain 0..1 coarse film grain
@@ -138,11 +147,16 @@ patina_edu_film <- function(
 }
 
 
-#' Animate an educational-film segment (gate weave, flicker, dust per frame)
+#' Animate an educational-film segment
 #'
-#' Builds an animated GIF that looks like a short 16mm instructional clip.
-#' Each frame calls `patina_edu_film()` with per-frame jitter and seed,
-#' then adds slight brightness flicker and tiny XY weave. Dimensions are preserved.
+#' Builds an animated GIF of a short 16mm instructional clip with gate weave,
+#' flicker, and per-frame dust.
+#'
+#' @examples
+#' if (requireNamespace("magick", quietly = TRUE)) {
+#'   img <- magick::image_read("logo:")
+#'   animate_edu_film(img, n_frames = 5, fps = 2)
+#' }
 #'
 #' @param img magick image (your rasterized ggplot)
 #' @param n_frames number of frames (e.g., 48)

--- a/R/effect_ink_bleed.R
+++ b/R/effect_ink_bleed.R
@@ -1,4 +1,13 @@
-#' Ink bleeding into paper fibers (fixed)
+#' Ink bleed effect
+#'
+#' Simulates ink bleeding into paper fibers.
+#'
+#' @examples
+#' if (requireNamespace("magick", quietly = TRUE)) {
+#'   img <- magick::image_read("logo:")
+#'   patina_ink_bleed(img)
+#' }
+#'
 #' @param img magick image (from as_magick)
 #' @param radius feather (sigma) in px for the bleed falloff
 #' @param expand dilation (px) to push the bleed outward from strokes

--- a/R/effect_kodachrome.R
+++ b/R/effect_kodachrome.R
@@ -1,4 +1,12 @@
-#' Faded, overexposed Kodachrome vibe (warm cast + halation + grain)
+#' Kodachrome effect
+#'
+#' Adds a warm cast, halation glow, and grain for a faded Kodachrome vibe.
+#'
+#' @examples
+#' if (requireNamespace("magick", quietly = TRUE)) {
+#'   img <- magick::image_read("logo:")
+#'   patina_kodachrome(img)
+#' }
 #'
 #' @param img magick image (rasterized plot).
 #' @param warmth 0..1 warm colorize.

--- a/R/effect_newscast.R
+++ b/R/effect_newscast.R
@@ -1,4 +1,13 @@
-#' Old newscast preset (scanlines, chroma bleed, tube glow, vignette, grain)
+#' Old newscast effect
+#'
+#' Adds scanlines, chroma bleed, tube glow, vignette, and noise to mimic a CRT
+#' broadcast.
+#'
+#' @examples
+#' if (requireNamespace("magick", quietly = TRUE)) {
+#'   img <- magick::image_read("logo:")
+#'   patina_newscast(img)
+#' }
 #'
 #' @param img magick image
 #' @param sat saturation multiplier (1 = unchanged)

--- a/R/effect_newspaper.R
+++ b/R/effect_newspaper.R
@@ -1,4 +1,13 @@
-#' Old newspaper preset (readable defaults: light page, crisp ink, subtle dots)
+#' Old newspaper effect
+#'
+#' Creates a light newsprint look with crisp ink, subtle dots, and optional
+#' paper texture.
+#'
+#' @examples
+#' if (requireNamespace("magick", quietly = TRUE)) {
+#'   img <- magick::image_read("logo:")
+#'   patina_newspaper(img)
+#' }
 #'
 #' @param img magick image (rasterized plot)
 #' @param halftone 0..1 strength of dot pattern (applied to background only)

--- a/R/effect_photocopy.R
+++ b/R/effect_photocopy.R
@@ -11,7 +11,16 @@
   magick::image_fx(img, fx)
 }
 
-#' Photocopier double-pass misalignment (ghost + banding, line-safe, adjustable wash)
+#' Photocopier double-pass effect
+#'
+#' Adds a ghost offset, banding, and adjustable wash while protecting dark lines.
+#'
+#' @examples
+#' if (requireNamespace("magick", quietly = TRUE)) {
+#'   img <- magick::image_read("logo:")
+#'   patina_photocopy(img)
+#' }
+#'
 #' @param img magick image
 #' @param offset c(x,y) ghost offset in px
 #' @param ghost_opacity 0..1 opacity of the ghost pass

--- a/R/hand_drawn.R
+++ b/R/hand_drawn.R
@@ -191,7 +191,15 @@ displace_map <- function(w, h, freq = 0.6, seed = 3, gate = NULL, edge_guard = 0
 }
 
 # ========= main API ==========================================================
-#' Hand-drawn wobble (post-processing; auto scale; exact panel mask for ggplot)
+#' Hand-drawn wobble
+#'
+#' Adds a sketchy wobble with automatic scaling and panel masking.
+#'
+#' @examples
+#' if (requireNamespace("ggplot2", quietly = TRUE)) {
+#'   p <- ggplot2::ggplot(mtcars, ggplot2::aes(wt, mpg)) + ggplot2::geom_point()
+#'   hand_drawn_wiggle(p)
+#' }
 #'
 #' @param x ggplot/grob or magick-image
 #' @param width,height,dpi Used when x is ggplot/grob

--- a/R/period_fonts.R
+++ b/R/period_fonts.R
@@ -82,12 +82,18 @@
   fam
 }
 
-#' Apply period fonts in place (fonts only)
+#' Apply period fonts in place
 #'
 #' Changes only the `family` of text elements on a ggplot, preserving size, face,
 #' colour, margins, and element classes. When an element is missing and needs to
 #' be created (scope = "all_listed"), it is cloned from the current/global theme
 #' first so sizes never reset.
+#'
+#' @examples
+#' if (requireNamespace("ggplot2", quietly = TRUE)) {
+#'   p <- ggplot2::ggplot(mtcars, ggplot2::aes(wt, mpg)) + ggplot2::geom_point()
+#'   apply_period_fonts(p)
+#' }
 #'
 #' @param p A ggplot.
 #' @param era One of: "journal-1930s","journal-1960s","slide-1970s",
@@ -130,7 +136,18 @@ apply_period_fonts <- function(p,
   p
 }
 
-#' Period font theme (fonts only; clones sizes from current global theme)
+#' Period font theme
+#'
+#' Returns a theme that swaps font families while preserving sizes from the
+#' current global theme.
+#'
+#' @examples
+#' if (requireNamespace("ggplot2", quietly = TRUE)) {
+#'   ggplot2::ggplot(mtcars, ggplot2::aes(wt, mpg)) +
+#'     ggplot2::geom_point() +
+#'     period_font_theme()
+#' }
+#'
 #' @inheritParams apply_period_fonts
 #' @return A `ggplot2::theme` that changes only font families on listed elements.
 #' @export

--- a/R/preset_journal_scan.R
+++ b/R/preset_journal_scan.R
@@ -1,5 +1,13 @@
-#' Old journal scan (sepia/mono, soft dither, paper, rotating top shadow)
-#' Shadow is drawn in a top margin first, then the whole page is rotated.
+#' Old journal scan preset
+#'
+#' Adds sepia tone, soft dither, paper texture, and a rotating top shadow.
+#' The shadow is drawn in a top margin before rotating the whole page.
+#'
+#' @examples
+#' if (requireNamespace("magick", quietly = TRUE)) {
+#'   img <- magick::image_read("logo:")
+#'   scanify_journal(img)
+#' }
 #'
 #' @param img magick image
 #' @param paper optional path/URL to paper texture

--- a/R/preset_transparency.R
+++ b/R/preset_transparency.R
@@ -1,4 +1,13 @@
-#' Transparency slide preset (chromatic offset, light leak, vignette, grain)
+#' Transparency slide preset
+#'
+#' Applies chromatic offset, light leaks, vignette, and grain for a vintage
+#' slide look.
+#'
+#' @examples
+#' if (requireNamespace("magick", quietly = TRUE)) {
+#'   img <- magick::image_read("logo:")
+#'   slideify_transparency(img)
+#' }
 #'
 #' @param img magick image
 #' @param ca_px integer pixel shift for R/B channels (chromatic aberration)

--- a/R/themes.R
+++ b/R/themes.R
@@ -1,4 +1,13 @@
-#' Newspaper-style theme (off-white, crisp axes, dashed majors)
+#' Newspaper theme
+#'
+#' Off-white page with crisp axes and dashed major grid lines.
+#'
+#' @examples
+#' if (requireNamespace("ggplot2", quietly = TRUE)) {
+#'   ggplot2::ggplot(mtcars, ggplot2::aes(wt, mpg)) +
+#'     ggplot2::geom_point() +
+#'     theme_newspaper()
+#' }
 #'
 #' @param base_size base text size
 #' @param base_family font family (optional)
@@ -23,7 +32,16 @@ theme_newspaper <- function(base_size = 11, base_family = NULL,
     )
 }
 
-#' Newscast/CRT theme (dark UI, light ink, faint grid)
+#' Newscast theme
+#'
+#' Dark background with light ink, faint grid, and CRT-inspired styling.
+#'
+#' @examples
+#' if (requireNamespace("ggplot2", quietly = TRUE)) {
+#'   ggplot2::ggplot(mtcars, ggplot2::aes(wt, mpg)) +
+#'     ggplot2::geom_point() +
+#'     theme_newscast()
+#' }
 #'
 #' @param base_size base text size
 #' @param base_family font family (optional)
@@ -52,7 +70,16 @@ theme_newscast <- function(base_size = 11, base_family = NULL,
     )
 }
 
-#' Educational-film theme (warm page, dotted majors, gentle border)
+#' Educational-film theme
+#'
+#' Warm page tones with dotted majors and a subtle border.
+#'
+#' @examples
+#' if (requireNamespace("ggplot2", quietly = TRUE)) {
+#'   ggplot2::ggplot(mtcars, ggplot2::aes(wt, mpg)) +
+#'     ggplot2::geom_point() +
+#'     theme_edu_film()
+#' }
 #'
 #' @param base_size base text size
 #' @param base_family font family (optional)
@@ -80,7 +107,16 @@ theme_edu_film <- function(base_size = 11, base_family = NULL,
     )
 }
 
-#' Transparency-slide theme (clean white, thin grid, generous margins)
+#' Transparency-slide theme
+#'
+#' Clean white slide with a thin grid and generous margins.
+#'
+#' @examples
+#' if (requireNamespace("ggplot2", quietly = TRUE)) {
+#'   ggplot2::ggplot(mtcars, ggplot2::aes(wt, mpg)) +
+#'     ggplot2::geom_point() +
+#'     theme_transparency()
+#' }
 #'
 #' @param base_size base text size
 #' @param base_family font family (optional)
@@ -101,7 +137,16 @@ theme_transparency <- function(base_size = 11, base_family = NULL,
     )
 }
 
-#' Blueprint theme (navy page, cyan lines, high-contrast text)
+#' Blueprint theme
+#'
+#' Navy background with cyan lines and high-contrast text.
+#'
+#' @examples
+#' if (requireNamespace("ggplot2", quietly = TRUE)) {
+#'   ggplot2::ggplot(mtcars, ggplot2::aes(wt, mpg)) +
+#'     ggplot2::geom_point() +
+#'     theme_blueprint()
+#' }
 #'
 #' @param base_size base text size
 #' @param base_family font family (optional)
@@ -132,12 +177,10 @@ theme_blueprint <- function(base_size = 11, base_family = NULL,
 }
 
 
-#' Journal-style theme core (print-friendly)
+#' Journal-style theme core
 #'
-#' A small, conservative theme scaffold tuned for old-fashioned journals:
-#' clear axes, restrained grids, and white backgrounds. It avoids touching
-#' text sizes—only layout, lines, and colors—so it plays nicely with your
-#' own font helpers.
+#' Conservative scaffold for journals: clear axes, restrained grids, white
+#' backgrounds, and no font-size changes so it plays nicely with font helpers.
 #'
 #' @param base_size Numeric base text size passed to \code{ggplot2::theme_minimal()}.
 #'   Defaults to 11. This does not change sizes you have already set explicitly.
@@ -326,9 +369,9 @@ scale_fill_journal <- function(era = c("1900s","1930s","1960s"),
   }
 }
 
-#' Continuous grayscale for journal themes (color)
+#' Continuous grayscale scale (color)
 #'
-#' A simple two-stop gradient that prints/reproduces well with patinas.
+#' Two-stop gradient that prints well with journal patinas.
 #'
 #' @param low,high Hex colors for the gradient endpoints.
 #' @param ... Passed to \code{ggplot2::scale_color_gradient()}.
@@ -340,7 +383,7 @@ scale_color_journal_continuous <- function(low = "#0f0f0f", high = "#adadad", ..
   ggplot2::scale_color_gradient(low = low, high = high, ...)
 }
 
-#' Continuous grayscale for journal themes (fill)
+#' Continuous grayscale scale (fill)
 #'
 #' @inheritParams scale_color_journal_continuous
 #' @return A continuous fill scale.

--- a/man/animate_edu_film.Rd
+++ b/man/animate_edu_film.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/effect_edu_film.R
 \name{animate_edu_film}
 \alias{animate_edu_film}
-\title{Animate an educational-film segment (gate weave, flicker, dust per frame)}
+\title{Animate an educational-film segment}
 \usage{
 animate_edu_film(
   img,
@@ -48,7 +48,13 @@ animate_edu_film(
 an animated magick-image (GIF). If \code{write_gif} is provided, the file is also written.
 }
 \description{
-Builds an animated GIF that looks like a short 16mm instructional clip.
+Builds an animated GIF of a short 16mm instructional clip with gate weave, flicker, and per-frame dust.
 Each frame calls \code{patina_edu_film()} with per-frame jitter and seed,
 then adds slight brightness flicker and tiny XY weave. Dimensions are preserved.
+}
+\examples{
+if (requireNamespace("magick", quietly = TRUE)) {
+  img <- magick::image_read("logo:")
+  animate_edu_film(img, n_frames = 5, fps = 2)
+}
 }

--- a/man/apply_period_fonts.Rd
+++ b/man/apply_period_fonts.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/period_fonts.R
 \name{apply_period_fonts}
 \alias{apply_period_fonts}
-\title{Apply period fonts in place (fonts only)}
+\title{Apply period fonts in place}
 \usage{
 apply_period_fonts(
   p,
@@ -32,4 +32,10 @@ Changes only the \code{family} of text elements on a ggplot, preserving size, fa
 colour, margins, and element classes. When an element is missing and needs to
 be created (scope = "all_listed"), it is cloned from the current/global theme
 first so sizes never reset.
+}
+\examples{
+if (requireNamespace("ggplot2", quietly = TRUE)) {
+  p <- ggplot2::ggplot(mtcars, ggplot2::aes(wt, mpg)) + ggplot2::geom_point()
+  apply_period_fonts(p)
+}
 }

--- a/man/hand_drawn_wiggle.Rd
+++ b/man/hand_drawn_wiggle.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/hand_drawn.R
 \name{hand_drawn_wiggle}
 \alias{hand_drawn_wiggle}
-\title{Hand-drawn wobble (post-processing; auto scale; exact panel mask for ggplot)}
+\title{Hand-drawn wobble}
 \usage{
 hand_drawn_wiggle(
   x,
@@ -47,5 +47,11 @@ hand_drawn_wiggle(
 magick-image
 }
 \description{
-Hand-drawn wobble (post-processing; auto scale; exact panel mask for ggplot)
+Adds a sketchy wobble with automatic scaling and panel masking.
+}
+\examples{
+if (requireNamespace("ggplot2", quietly = TRUE)) {
+  p <- ggplot2::ggplot(mtcars, ggplot2::aes(wt, mpg)) + ggplot2::geom_point()
+  hand_drawn_wiggle(p)
+}
 }

--- a/man/patina_blueprint.Rd
+++ b/man/patina_blueprint.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/effect_blueprint.R
 \name{patina_blueprint}
 \alias{patina_blueprint}
-\title{Blueprint (cyanotype) style}
+\title{Blueprint style}
 \usage{
 patina_blueprint(
   img,
@@ -27,5 +27,11 @@ patina_blueprint(
 \item{line_soften}{Gaussian sigma for softening line mask.}
 }
 \description{
-Blueprint (cyanotype) style
+Creates a cyanotype blueprint effect with optional grid and paper texture.
+}
+\examples{
+if (requireNamespace("magick", quietly = TRUE)) {
+  img <- magick::image_read("logo:")
+  patina_blueprint(img)
+}
 }

--- a/man/patina_edu_film.Rd
+++ b/man/patina_edu_film.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/effect_edu_film.R
 \name{patina_edu_film}
 \alias{patina_edu_film}
-\title{Old educational film preset (warm/green cast, big grain, dust & scratches)}
+\title{Old educational film preset}
 \usage{
 patina_edu_film(
   img,
@@ -45,5 +45,11 @@ patina_edu_film(
 \item{scratches}{integer number of vertical scratches to draw (0 = none)}
 }
 \description{
-Old educational film preset (warm/green cast, big grain, dust & scratches)
+Adds a warm/green cast, heavy grain, dust, scratches, and slight weave for a classroom 16mm look.
+}
+\examples{
+if (requireNamespace("magick", quietly = TRUE)) {
+  img <- magick::image_read("logo:")
+  patina_edu_film(img)
+}
 }

--- a/man/patina_ink_bleed.Rd
+++ b/man/patina_ink_bleed.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/effect_ink_bleed.R
 \name{patina_ink_bleed}
 \alias{patina_ink_bleed}
-\title{Ink bleeding into paper fibers (fixed)}
+\title{Ink bleed effect}
 \usage{
 patina_ink_bleed(
   img,
@@ -27,5 +27,11 @@ patina_ink_bleed(
 \item{paper_texture}{optional texture laid UNDER the plot}
 }
 \description{
-Ink bleeding into paper fibers (fixed)
+Simulates ink bleeding into paper fibers.
+}
+\examples{
+if (requireNamespace("magick", quietly = TRUE)) {
+  img <- magick::image_read("logo:")
+  patina_ink_bleed(img)
+}
 }

--- a/man/patina_kodachrome.Rd
+++ b/man/patina_kodachrome.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/effect_kodachrome.R
 \name{patina_kodachrome}
 \alias{patina_kodachrome}
-\title{Faded, overexposed Kodachrome vibe (warm cast + halation + grain)}
+\title{Kodachrome effect}
 \usage{
 patina_kodachrome(img, warmth = 0.25, fade = 0.25, bloom = 0.35, grain = 0.6)
 }
@@ -18,5 +18,11 @@ patina_kodachrome(img, warmth = 0.25, fade = 0.25, bloom = 0.35, grain = 0.6)
 \item{grain}{0..1 grain amount.}
 }
 \description{
-Faded, overexposed Kodachrome vibe (warm cast + halation + grain)
+Adds a warm cast, halation glow, and grain for a faded Kodachrome vibe.
+}
+\examples{
+if (requireNamespace("magick", quietly = TRUE)) {
+  img <- magick::image_read("logo:")
+  patina_kodachrome(img)
+}
 }

--- a/man/patina_newscast.Rd
+++ b/man/patina_newscast.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/effect_newscast.R
 \name{patina_newscast}
 \alias{patina_newscast}
-\title{Old newscast preset (scanlines, chroma bleed, tube glow, vignette, grain)}
+\title{Old newscast effect}
 \usage{
 patina_newscast(
   img,
@@ -48,5 +48,11 @@ patina_newscast(
 \item{corner_margin}{fraction margin from edges when placing the corner region}
 }
 \description{
-Old newscast preset (scanlines, chroma bleed, tube glow, vignette, grain)
+Adds scanlines, chroma bleed, tube glow, vignette, and noise to mimic a CRT broadcast.
+}
+\examples{
+if (requireNamespace("magick", quietly = TRUE)) {
+  img <- magick::image_read("logo:")
+  patina_newscast(img)
+}
 }

--- a/man/patina_newspaper.Rd
+++ b/man/patina_newspaper.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/effect_newspaper.R
 \name{patina_newspaper}
 \alias{patina_newspaper}
-\title{Old newspaper preset (readable defaults: light page, crisp ink, subtle dots)}
+\title{Old newspaper effect}
 \usage{
 patina_newspaper(
   img,
@@ -45,5 +45,11 @@ patina_newspaper(
 \item{line_gain}{0..1 deepen only the ink strokes after effects}
 }
 \description{
-Old newspaper preset (readable defaults: light page, crisp ink, subtle dots)
+Creates a light newsprint look with crisp ink, subtle dots, and optional paper texture.
+}
+\examples{
+if (requireNamespace("magick", quietly = TRUE)) {
+  img <- magick::image_read("logo:")
+  patina_newspaper(img)
+}
 }

--- a/man/patina_photocopy.Rd
+++ b/man/patina_photocopy.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/effect_photocopy.R
 \name{patina_photocopy}
 \alias{patina_photocopy}
-\title{Photocopier double-pass misalignment (ghost + banding, line-safe, adjustable wash)}
+\title{Photocopier double-pass effect}
 \usage{
 patina_photocopy(
   img,
@@ -36,5 +36,11 @@ patina_photocopy(
 \item{contrast_pop}{strength of final sigmoid contrast (0 = none)}
 }
 \description{
-Photocopier double-pass misalignment (ghost + banding, line-safe, adjustable wash)
+Adds a ghost offset, banding, and adjustable wash while protecting dark lines.
+}
+\examples{
+if (requireNamespace("magick", quietly = TRUE)) {
+  img <- magick::image_read("logo:")
+  patina_photocopy(img)
+}
 }

--- a/man/period_font_theme.Rd
+++ b/man/period_font_theme.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/period_fonts.R
 \name{period_font_theme}
 \alias{period_font_theme}
-\title{Period font theme (fonts only; clones sizes from current global theme)}
+\title{Period font theme}
 \usage{
 period_font_theme(
   era = c("journal-1930s", "journal-1960s", "slide-1970s", "slide-1980s",
@@ -26,5 +26,12 @@ missing listed elements by cloning a template).}
 A \code{ggplot2::theme} that changes only font families on listed elements.
 }
 \description{
-Period font theme (fonts only; clones sizes from current global theme)
+Returns a theme that swaps font families while preserving sizes from the current global theme.
+}
+\examples{
+if (requireNamespace("ggplot2", quietly = TRUE)) {
+  ggplot2::ggplot(mtcars, ggplot2::aes(wt, mpg)) +
+    ggplot2::geom_point() +
+    period_font_theme()
+}
 }

--- a/man/scale_color_journal_continuous.Rd
+++ b/man/scale_color_journal_continuous.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/themes.R
 \name{scale_color_journal_continuous}
 \alias{scale_color_journal_continuous}
-\title{Continuous grayscale for journal themes (color)}
+\title{Continuous grayscale scale (color)}
 \usage{
 scale_color_journal_continuous(low = "#0f0f0f", high = "#adadad", ...)
 }
@@ -15,7 +15,7 @@ scale_color_journal_continuous(low = "#0f0f0f", high = "#adadad", ...)
 A continuous color scale.
 }
 \description{
-A simple two-stop gradient that prints/reproduces well with patinas.
+Two-stop gradient that prints well with journal patinas.
 }
 \examples{
 # p + scale_color_journal_continuous()

--- a/man/scale_fill_journal_continuous.Rd
+++ b/man/scale_fill_journal_continuous.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/themes.R
 \name{scale_fill_journal_continuous}
 \alias{scale_fill_journal_continuous}
-\title{Continuous grayscale for journal themes (fill)}
+\title{Continuous grayscale scale (fill)}
 \usage{
 scale_fill_journal_continuous(low = "#0f0f0f", high = "#adadad", ...)
 }
@@ -15,7 +15,7 @@ scale_fill_journal_continuous(low = "#0f0f0f", high = "#adadad", ...)
 A continuous fill scale.
 }
 \description{
-Continuous grayscale for journal themes (fill)
+Two-stop gradient for fill aesthetics that prints well with journal patinas.
 }
 \examples{
 # p + scale_fill_journal_continuous()

--- a/man/scanify_journal.Rd
+++ b/man/scanify_journal.Rd
@@ -2,8 +2,7 @@
 % Please edit documentation in R/preset_journal_scan.R
 \name{scanify_journal}
 \alias{scanify_journal}
-\title{Old journal scan (sepia/mono, soft dither, paper, rotating top shadow)
-Shadow is drawn in a top margin first, then the whole page is rotated.}
+\title{Old journal scan preset}
 \usage{
 scanify_journal(
   img,
@@ -40,6 +39,11 @@ scanify_journal(
 \item{saturation}{If not sepia toned, color saturation}
 }
 \description{
-Old journal scan (sepia/mono, soft dither, paper, rotating top shadow)
-Shadow is drawn in a top margin first, then the whole page is rotated.
+Adds sepia tone, soft dither, paper texture, and a rotating top shadow. The shadow is drawn in a top margin before rotating the whole page.
+}
+\examples{
+if (requireNamespace("magick", quietly = TRUE)) {
+  img <- magick::image_read("logo:")
+  scanify_journal(img)
+}
 }

--- a/man/slideify_transparency.Rd
+++ b/man/slideify_transparency.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/preset_transparency.R
 \name{slideify_transparency}
 \alias{slideify_transparency}
-\title{Transparency slide preset (chromatic offset, light leak, vignette, grain)}
+\title{Transparency slide preset}
 \usage{
 slideify_transparency(
   img,
@@ -33,5 +33,11 @@ slideify_transparency(
 \item{grain}{0..1 film grain strength}
 }
 \description{
-Transparency slide preset (chromatic offset, light leak, vignette, grain)
+Applies chromatic offset, light leaks, vignette, and grain for a vintage slide look.
+}
+\examples{
+if (requireNamespace("magick", quietly = TRUE)) {
+  img <- magick::image_read("logo:")
+  slideify_transparency(img)
+}
 }

--- a/man/theme_blueprint.Rd
+++ b/man/theme_blueprint.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/themes.R
 \name{theme_blueprint}
 \alias{theme_blueprint}
-\title{Blueprint theme (navy page, cyan lines, high-contrast text)}
+\title{Blueprint theme}
 \usage{
 theme_blueprint(
   base_size = 11,
@@ -24,5 +24,12 @@ theme_blueprint(
 \item{grid_col}{grid color}
 }
 \description{
-Blueprint theme (navy page, cyan lines, high-contrast text)
+Navy background with cyan lines and high-contrast text.
+}
+\examples{
+if (requireNamespace("ggplot2", quietly = TRUE)) {
+  ggplot2::ggplot(mtcars, ggplot2::aes(wt, mpg)) +
+    ggplot2::geom_point() +
+    theme_blueprint()
+}
 }

--- a/man/theme_edu_film.Rd
+++ b/man/theme_edu_film.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/themes.R
 \name{theme_edu_film}
 \alias{theme_edu_film}
-\title{Educational-film theme (warm page, dotted majors, gentle border)}
+\title{Educational-film theme}
 \usage{
 theme_edu_film(
   base_size = 11,
@@ -24,5 +24,12 @@ theme_edu_film(
 \item{grid_col}{major grid color}
 }
 \description{
-Educational-film theme (warm page, dotted majors, gentle border)
+Warm page tones with dotted majors and a subtle border.
+}
+\examples{
+if (requireNamespace("ggplot2", quietly = TRUE)) {
+  ggplot2::ggplot(mtcars, ggplot2::aes(wt, mpg)) +
+    ggplot2::geom_point() +
+    theme_edu_film()
+}
 }

--- a/man/theme_journal_core.Rd
+++ b/man/theme_journal_core.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/themes.R
 \name{theme_journal_core}
 \alias{theme_journal_core}
-\title{Journal-style theme core (print-friendly)}
+\title{Journal-style theme core}
 \usage{
 theme_journal_core(
   base_size = 11,
@@ -35,10 +35,8 @@ Defaults to 11. This does not change sizes you have already set explicitly.}
 A \code{ggplot2::theme} object.
 }
 \description{
-A small, conservative theme scaffold tuned for old-fashioned journals:
-clear axes, restrained grids, and white backgrounds. It avoids touching
-text sizes—only layout, lines, and colors—so it plays nicely with your
-own font helpers.
+Conservative scaffold for journals: clear axes, restrained grids, white
+backgrounds, and no font-size changes so it plays nicely with font helpers.
 }
 \examples{
 if (requireNamespace("ggplot2", quietly = TRUE)) {

--- a/man/theme_newscast.Rd
+++ b/man/theme_newscast.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/themes.R
 \name{theme_newscast}
 \alias{theme_newscast}
-\title{Newscast/CRT theme (dark UI, light ink, faint grid)}
+\title{Newscast theme}
 \usage{
 theme_newscast(
   base_size = 11,
@@ -24,5 +24,12 @@ theme_newscast(
 \item{grid_col}{grid color (low alpha)}
 }
 \description{
-Newscast/CRT theme (dark UI, light ink, faint grid)
+Dark background with light ink, faint grid, and CRT-inspired styling.
+}
+\examples{
+if (requireNamespace("ggplot2", quietly = TRUE)) {
+  ggplot2::ggplot(mtcars, ggplot2::aes(wt, mpg)) +
+    ggplot2::geom_point() +
+    theme_newscast()
+}
 }

--- a/man/theme_newspaper.Rd
+++ b/man/theme_newspaper.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/themes.R
 \name{theme_newspaper}
 \alias{theme_newspaper}
-\title{Newspaper-style theme (off-white, crisp axes, dashed majors)}
+\title{Newspaper theme}
 \usage{
 theme_newspaper(
   base_size = 11,
@@ -24,5 +24,12 @@ theme_newspaper(
 \item{grid_col}{major grid line color}
 }
 \description{
-Newspaper-style theme (off-white, crisp axes, dashed majors)
+Off-white page with crisp axes and dashed major grid lines.
+}
+\examples{
+if (requireNamespace("ggplot2", quietly = TRUE)) {
+  ggplot2::ggplot(mtcars, ggplot2::aes(wt, mpg)) +
+    ggplot2::geom_point() +
+    theme_newspaper()
+}
 }

--- a/man/theme_transparency.Rd
+++ b/man/theme_transparency.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/themes.R
 \name{theme_transparency}
 \alias{theme_transparency}
-\title{Transparency-slide theme (clean white, thin grid, generous margins)}
+\title{Transparency-slide theme}
 \usage{
 theme_transparency(
   base_size = 11,
@@ -21,5 +21,12 @@ theme_transparency(
 \item{grid_col}{grid color}
 }
 \description{
-Transparency-slide theme (clean white, thin grid, generous margins)
+Clean white slide with a thin grid and generous margins.
+}
+\examples{
+if (requireNamespace("ggplot2", quietly = TRUE)) {
+  ggplot2::ggplot(mtcars, ggplot2::aes(wt, mpg)) +
+    ggplot2::geom_point() +
+    theme_transparency()
+}
 }


### PR DESCRIPTION
## Summary
- Clarify patina effect documentation with succinct titles and richer descriptions
- Expand theme and font helper docs with practical examples
- Add usage examples across key effects, presets, and themes
- Streamline `scanify_journal` docs with a concise title and clearer description

## Testing
- `R -q -e 'testthat::test_dir("tests/testthat")'` *(fails: command not found: R)*

------
https://chatgpt.com/codex/tasks/task_e_689b56d74cd0832ca70c53155bb1c299