### PR TITLE
Handle ggplot2 4.0 S7 elements in font helpers

### DIFF
--- a/R/period_fonts.R
+++ b/R/period_fonts.R
@@ -29,7 +29,8 @@
 #' @noRd
 .set_family <- function(el, family) {
   if (is.null(el) || inherits(el, "element_blank")) return(el)
-  if ("family" %in% names(el)) el$family <- family
+  # ggplot2 4.0 elements are S7 objects without names(), but still support `$family`
+  try({ el$family <- family }, silent = TRUE)
   el
 }
 


### PR DESCRIPTION
## Summary
- ensure `.set_family()` assigns `family` for S7 `element_text` objects in ggplot2 4.0

## Testing
- `_R_CHECK_FORCE_SUGGESTS_=false R CMD check --no-manual --ignore-vignettes .`


------
https://chatgpt.com/codex/tasks/task_e_68ac8cff7ee4832c913e4235466134f0